### PR TITLE
Update test-and-release.yml - add node.js 22.x tests

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
Testing at node.js 22 is required unless there is a now restriction / problem with node.js 22 and an isseu exists to track this..
Please merge PR (if tests are or).

Releated to #64 